### PR TITLE
feat(bzzdb): initial implementation

### DIFF
--- a/pkg/bzzdb/bzzdb.go
+++ b/pkg/bzzdb/bzzdb.go
@@ -4,33 +4,152 @@
 
 package bzzdb
 
-func New() KeyValueStore {
-	return &bzzdb{}
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"io"
+
+	"github.com/ethersphere/bee/pkg/swarm"
+
+	"github.com/ethersphere/eth-on-bzz/pkg/client"
+	"github.com/ethersphere/eth-on-bzz/pkg/postage"
+)
+
+const (
+	deletedSOCData = "deleted"
+	keyPrefix      = "bzzdb-"
+)
+
+var errBzzDBNotFound = errors.New("not found")
+
+func New(
+	privKey *ecdsa.PrivateKey,
+	beeCli client.Client,
+) KeyValueStore {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &bzzdb{
+		privKey:   privKey,
+		beeCli:    beeCli,
+		postage:   postage.New(beeCli),
+		ctx:       ctx,
+		ctxCancel: cancel,
+	}
 }
 
-type bzzdb struct{}
+// bzzdb implements ethereum KeyValueStore interface.
+type bzzdb struct {
+	privKey *ecdsa.PrivateKey
+	beeCli  client.Client
+	postage postage.Postage
+
+	//nolint:containedctx // this ctx is need because methods of KeyValueStore
+	// interface do not pass down context. Single context is created in New method
+	// and reused for all Bee Client calls.
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
 
 func (db *bzzdb) Has(key []byte) (bool, error) {
-	v, err := db.Get(key)
-	if err != nil {
+	if _, err := db.Get(key); err != nil {
+		if errors.Is(err, errBzzDBNotFound) {
+			return false, nil
+		}
+
+		if errors.Is(err, client.ErrNotFound) {
+			return false, nil
+		}
+
 		return false, err
 	}
 
-	return v != nil, nil
+	return true, nil
 }
 
+//nolint:wrapcheck //relax
 func (db *bzzdb) Get(key []byte) ([]byte, error) {
-	return nil, nil
+	owner, err := client.OwnerFromKey(db.privKey)
+	if err != nil {
+		return nil, err
+	}
+
+	feedResp, err := db.beeCli.FeedGet(db.ctx, owner, makeKey(key))
+	if err != nil {
+		return nil, err
+	}
+
+	addr := feedResp.Current
+	if bytes.Equal(addr, []byte(deletedSOCData)) {
+		return nil, errBzzDBNotFound
+	}
+
+	body, err := db.beeCli.Download(db.ctx, swarm.NewAddress(addr))
+	if err != nil {
+		return nil, err
+	}
+
+	defer body.Close()
+
+	return io.ReadAll(body)
 }
 
+//nolint:wrapcheck //relax
 func (db *bzzdb) Put(key []byte, value []byte) error {
+	batchID, err := db.postage.CurrentBatchID()
+	if err != nil {
+		return err
+	}
+
+	uploadResp, err := db.beeCli.Upload(db.ctx, value, batchID)
+	if err != nil {
+		return err
+	}
+
+	data := uploadResp.Reference.Bytes()
+
+	sig, owner, err := client.SignSocData([]byte(makeKey(key)), data, db.privKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.beeCli.UploadSOC(db.ctx, owner, makeKey(key), data, sig, batchID)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
+//nolint:wrapcheck //relax
 func (db *bzzdb) Delete(key []byte) error {
+	batchID, err := db.postage.CurrentBatchID()
+	if err != nil {
+		return err
+	}
+
+	data := []byte(deletedSOCData)
+
+	sig, owner, err := client.SignSocData([]byte(makeKey(key)), data, db.privKey)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.beeCli.UploadSOC(db.ctx, owner, makeKey(key), data, sig, batchID)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (db *bzzdb) Close() error {
+	db.ctxCancel()
+
 	return nil
+}
+
+func makeKey(key []byte) string {
+	return keyPrefix + string(key)
 }

--- a/pkg/bzzdb/bzzdb_int_test.go
+++ b/pkg/bzzdb/bzzdb_int_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The Swarm Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build integration
+// +build integration
+
+package bzzdb_test
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"testing"
+
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb"
+	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb/dbtest"
+	"github.com/ethersphere/eth-on-bzz/pkg/client"
+)
+
+const (
+	envNodeAddress = "NODE_ADDRESS"
+	envPrivateKey  = "PRIVATE_KEY"
+)
+
+func Test_BzzDB_Integration(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := crypto.GenerateSecp256k1Key()
+	assert.NoError(t, err)
+
+	beeCli := client.NewClient(client.Config{
+		NodeURL: getEnv(t, envNodeAddress),
+	})
+
+	newBzzDB := func() bzzdb.KeyValueStore {
+		db, err := bzzdb.New(privKey, beeCli)
+		assert.NoError(t, err)
+
+		return db
+	}
+
+	dbtest.TestDatabaseSuite(t, newBzzDB)
+}
+
+func getPrivateKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+
+	keyRaw := getEnv(t, envPrivateKey)
+	key, err := crypto.DecodeSecp256k1PrivateKey([]byte(keyRaw))
+	assert.NoError(t, err)
+
+	return key
+}
+
+func getEnv(t *testing.T, env string) string {
+	val := os.Getenv(env)
+	if val == "" {
+		assert.FailNow(t, "env variable is not provided", "missing env: %v", env)
+	}
+
+	return val
+}

--- a/pkg/bzzdb/bzzdb_test.go
+++ b/pkg/bzzdb/bzzdb_test.go
@@ -24,7 +24,10 @@ func TestBzzDB(t *testing.T) {
 	beeCli := mock.NewClient()
 
 	newBzzDB := func() bzzdb.KeyValueStore {
-		return bzzdb.New(privKey, beeCli)
+		db, err := bzzdb.New(privKey, beeCli)
+		assert.NoError(t, err)
+
+		return db
 	}
 
 	dbtest.TestDatabaseSuite(t, newBzzDB)

--- a/pkg/bzzdb/bzzdb_test.go
+++ b/pkg/bzzdb/bzzdb_test.go
@@ -1,22 +1,31 @@
-// Copyright 2022 The Swarm Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 // Copyright 2023 The Swarm Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package bzzdb_test
 
-// import (
-// 	"testing"
+import (
+	"testing"
 
-// 	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb"
-// 	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb/dbtest"
-// )
+	"github.com/ethersphere/bee/pkg/crypto"
+	"github.com/stretchr/testify/assert"
 
-// func TestBzzDB(t *testing.T) {
-// 	t.Parallel()
+	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb"
+	"github.com/ethersphere/eth-on-bzz/pkg/bzzdb/dbtest"
+	"github.com/ethersphere/eth-on-bzz/pkg/client/mock"
+)
 
-// 	dbtest.TestDatabaseSuite(t, bzzdb.New)
-// }
+func TestBzzDB(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := crypto.GenerateSecp256k1Key()
+	assert.NoError(t, err)
+
+	beeCli := mock.NewClient()
+
+	newBzzDB := func() bzzdb.KeyValueStore {
+		return bzzdb.New(privKey, beeCli)
+	}
+
+	dbtest.TestDatabaseSuite(t, newBzzDB)
+}


### PR DESCRIPTION
This PR:
- adds coarse implementation for eth's `KeyValueStore` interface (`bzzdb` struct)
- enabled eth's db tests to work with `bzzdb` and mock Bee client and real client via integration test.