### PR TITLE
chore(client): improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint: get-golangcilint
 # Runs tests on entire repo
 .PHONY: test
 test: 
-	go test  ./... -race -failfast -timeout=3s -count=1 
+	go test  ./... -race -failfast -timeout=5s -count=50 
 
 # Runs tests with integration components on entire repo
 .PHONY: test-integration

--- a/pkg/bzzdb/bzzdb.go
+++ b/pkg/bzzdb/bzzdb.go
@@ -112,7 +112,7 @@ func (db *bzzdb) Get(key []byte) ([]byte, error) {
 		return nil, errBzzDBNotFound
 	}
 
-	respData, err = db.downloadAndRead(db.beeCli.Download, swarm.NewAddress(respData))
+	respData, err = db.downloadAndRead(db.beeCli.DownloadBytes, swarm.NewAddress(respData))
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (db *bzzdb) uploadAsync(value []byte) <-chan uploadResp {
 			return
 		}
 
-		resp, err := db.beeCli.Upload(db.ctx, value, batchID)
+		resp, err := db.beeCli.UploadBytes(db.ctx, value, batchID)
 		if err != nil {
 			respC <- uploadResp{err: err}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -79,15 +79,15 @@ type (
 			immutable bool,
 		) (BuyStampResponse, error)
 
-		// Upload arbitrary bytes data via /bytes endpoint.
-		Upload(
+		// UploadBytes arbitrary bytes data via /bytes endpoint.
+		UploadBytes(
 			ctx context.Context,
 			data []byte,
 			batchID BatchID,
 		) (UploadResponse, error)
 
-		// Download bytes data via /bytes endpoint.
-		Download(
+		// DownloadBytes bytes data via /bytes endpoint.
+		DownloadBytes(
 			ctx context.Context,
 			addr swarm.Address,
 		) (io.ReadCloser, error)

--- a/pkg/client/clienttest/test_suite.go
+++ b/pkg/client/clienttest/test_suite.go
@@ -85,11 +85,11 @@ func (suite *TestSuite) TestUploadDownloadOk() {
 	for _, tc := range tests {
 		data := randomBytes(t, tc.size)
 
-		resp, err := c.Upload(ctx, data, batchID)
+		resp, err := c.UploadBytes(ctx, data, batchID)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, resp)
 
-		reader, err := c.Download(ctx, resp.Reference)
+		reader, err := c.DownloadBytes(ctx, resp.Reference)
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
 
@@ -109,7 +109,7 @@ func (suite *TestSuite) TestUploadError() {
 
 	data := randomBytes(t, 4)
 
-	resp, err := c.Upload(ctx, data, client.BatchID("invalid"))
+	resp, err := c.UploadBytes(ctx, data, client.BatchID("invalid"))
 	assert.Error(t, err)
 	assert.Empty(t, resp)
 }
@@ -122,7 +122,7 @@ func (suite *TestSuite) TestDownloadError() {
 	ctx := context.Background()
 
 	addr := swarm.NewAddress(randomBytes(t, swarm.HashSize))
-	reader, err := c.Download(ctx, addr)
+	reader, err := c.DownloadBytes(ctx, addr)
 	assert.Error(t, err)
 	assert.Nil(t, reader)
 }

--- a/pkg/client/impl.go
+++ b/pkg/client/impl.go
@@ -105,7 +105,7 @@ func (c *client) BuyStamp(
 	return resp, nil
 }
 
-func (c *client) Upload(
+func (c *client) UploadBytes(
 	ctx context.Context,
 	data []byte,
 	batchID BatchID,
@@ -133,7 +133,7 @@ func (c *client) Upload(
 	return resp, nil
 }
 
-func (c *client) Download(
+func (c *client) DownloadBytes(
 	ctx context.Context,
 	addr swarm.Address,
 ) (io.ReadCloser, error) {

--- a/pkg/client/mock/mock.go
+++ b/pkg/client/mock/mock.go
@@ -121,7 +121,7 @@ func (c *mockClient) BuyStamp(
 	return client.BuyStampResponse{BatchID: batchID}, nil
 }
 
-func (c *mockClient) Upload(
+func (c *mockClient) UploadBytes(
 	ctx context.Context,
 	data []byte,
 	batchID client.BatchID,
@@ -158,7 +158,7 @@ func (c *mockClient) upload(
 	return addr, nil
 }
 
-func (c *mockClient) Download(
+func (c *mockClient) DownloadBytes(
 	ctx context.Context,
 	addr swarm.Address,
 ) (io.ReadCloser, error) {
@@ -181,7 +181,7 @@ func (c *mockClient) DownloadChunk(
 	ctx context.Context,
 	addr swarm.Address,
 ) (io.ReadCloser, error) {
-	return c.Download(ctx, addr)
+	return c.DownloadBytes(ctx, addr)
 }
 
 func (c *mockClient) UploadSoc(


### PR DESCRIPTION
- `Client` interface methods `Upload` and `Download` were renamed to more descriptive names; `UploadBytes` and `DownloadBytes`, respectively
- Fixed data race issue in mock client impl
- Increased unit test runs in order to catch potential data race issues and flaky tests with higher probability